### PR TITLE
catalog: remove superfluous planChangeAlignment API

### DIFF
--- a/src/main/java/org/killbill/billing/catalog/api/Catalog.java
+++ b/src/main/java/org/killbill/billing/catalog/api/Catalog.java
@@ -165,9 +165,4 @@ public interface Catalog {
     public BillingAlignment billingAlignment(PlanPhaseSpecifier planPhase,
                                              DateTime requestedDate,
                                              DateTime subscriptionStartDate) throws CatalogApiException;
-
-    public PlanAlignmentChange planChangeAlignment(PlanPhaseSpecifier from,
-                                                   PlanSpecifier to,
-                                                   DateTime requestedDate,
-                                                   DateTime subscriptionStartDate) throws CatalogApiException;
 }

--- a/src/main/java/org/killbill/billing/catalog/api/StaticCatalog.java
+++ b/src/main/java/org/killbill/billing/catalog/api/StaticCatalog.java
@@ -110,9 +110,6 @@ public interface StaticCatalog {
 
     public BillingAlignment billingAlignment(PlanPhaseSpecifier planPhase) throws CatalogApiException;
 
-    public PlanAlignmentChange planChangeAlignment(PlanPhaseSpecifier from,
-                                                   PlanSpecifier to) throws CatalogApiException;
-
     public List<Listing> getAvailableBasePlanListings() throws CatalogApiException;
 
     public List<Listing> getAvailableAddOnListings(String baseProductName, String priceListName) throws CatalogApiException;


### PR DESCRIPTION
The `PlanAlignmentChange` can be retrieved by calling `planChange`.

See https://github.com/killbill/killbill/issues/784.