### PR TITLE
pom.xml: add dependency on jakarta.xml.bind-api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         java-version:
-          - 8
           - 11
+          - 16
         java-distribution:
           - adopt
           - zulu

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>


### PR DESCRIPTION
Required to support target JDK of 11+.