### PR TITLE
1375 - Renamed method to changePlanWithDateTime

### DIFF
--- a/src/main/java/org/killbill/billing/entitlement/api/Entitlement.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/Entitlement.java
@@ -340,7 +340,7 @@ public interface Entitlement extends Entity {
      * @throws EntitlementApiException if change failed
      */
     @RequiresPermissions(ENTITLEMENT_CAN_CHANGE_PLAN)
-    public Entitlement changePlanWithDate(final EntitlementSpecifier spec, final DateTime effectiveDate, final Iterable<PluginProperty> properties, final CallContext context)
+    public Entitlement changePlanWithDateTime(final EntitlementSpecifier spec, final DateTime effectiveDate, final Iterable<PluginProperty> properties, final CallContext context)
             throws EntitlementApiException;
     
 


### PR DESCRIPTION
Renamed `changePlanWithDate` to `changePlanWithDateTime`. This is because `changePlanWithDate` results in some ambiguous method calls in killbill tests (For example [here](https://github.com/killbill/killbill/blob/8e93f0a3192b0041a25684eb1190c9861f269366/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlementApi.java#L692)and in a few other places where a `null` value is passed.