### PR TITLE
Api 85 address spotbugs errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
         <system>Github</system>
         <url>https://github.com/killbill/killbill-api/issues</url>
     </issueManagement>
+    <properties>
+        <check.fail-spotbugs>true</check.fail-spotbugs>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2022 Equinix, Inc
+  ~ Copyright 2014-2022 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <Field type="org.joda.time.DateTime" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Field type="org.joda.time.Period" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+</FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -29,4 +29,14 @@
         <Field type="org.joda.time.Period" />
         <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
     </Match>
+    <Match>
+        <Class name="org.killbill.billing.BillingExceptionBase" />
+        <Method name="&lt;init&gt;" params="java.lang.Throwable,int,java.lang.String" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.BillingExceptionBase" />
+        <Method name="getCause" />
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/org/killbill/billing/BillingExceptionBase.java
+++ b/src/main/java/org/killbill/billing/BillingExceptionBase.java
@@ -25,23 +25,17 @@ public class BillingExceptionBase extends Exception {
     private final String formattedMsg;
 
     public BillingExceptionBase(final Throwable cause, final int code, final String msg) {
-        this.formattedMsg = msg;
+        this.cause = new Throwable(cause);
         this.code = code;
-        this.cause = cause;
+        this.formattedMsg = msg;
     }
 
     public BillingExceptionBase(final BillingExceptionBase cause) {
-        this.formattedMsg = cause.getMessage();
-        this.code = cause.getCode();
-        this.cause = cause;
+        this(cause, cause.getCode(), cause.getMessage());
     }
 
     public BillingExceptionBase(/* @Nullable */ final Throwable cause, final ErrorCode code, final Object... args) {
-        final String tmp;
-        tmp = String.format(code.getFormat(), args);
-        this.formattedMsg = tmp;
-        this.code = code.getCode();
-        this.cause = cause;
+        this(cause, code.getCode(), String.format(code.getFormat(), args));
     }
 
     public BillingExceptionBase(final ErrorCode code, final Object... args) {
@@ -55,7 +49,7 @@ public class BillingExceptionBase extends Exception {
 
     @Override
     public Throwable getCause() {
-        return cause;
+        return new Throwable(cause);
     }
 
     public int getCode() {

--- a/src/main/java/org/killbill/billing/BillingExceptionBase.java
+++ b/src/main/java/org/killbill/billing/BillingExceptionBase.java
@@ -25,7 +25,7 @@ public class BillingExceptionBase extends Exception {
     private final String formattedMsg;
 
     public BillingExceptionBase(final Throwable cause, final int code, final String msg) {
-        this.cause = new Throwable(cause);
+        this.cause = cause;
         this.code = code;
         this.formattedMsg = msg;
     }
@@ -49,7 +49,7 @@ public class BillingExceptionBase extends Exception {
 
     @Override
     public Throwable getCause() {
-        return new Throwable(cause);
+        return cause;
     }
 
     public int getCode() {

--- a/src/main/java/org/killbill/billing/osgi/api/Healthcheck.java
+++ b/src/main/java/org/killbill/billing/osgi/api/Healthcheck.java
@@ -32,7 +32,7 @@ public interface Healthcheck {
         private final Map details;
 
         public HealthStatus(final boolean healthy, final Map details) {
-            this.details = details;
+            this.details = Map.copyOf(details);
             this.healthy = healthy;
         }
 
@@ -53,7 +53,7 @@ public interface Healthcheck {
         }
 
         public Map getDetails() {
-            return details;
+            return Map.copyOf(details);
         }
     }
 }

--- a/src/main/java/org/killbill/billing/usage/api/SubscriptionUsageRecord.java
+++ b/src/main/java/org/killbill/billing/usage/api/SubscriptionUsageRecord.java
@@ -32,7 +32,7 @@ public class SubscriptionUsageRecord {
     public SubscriptionUsageRecord(final UUID subscriptionId, final String trackingId, final List<UnitUsageRecord> unitUsageRecord) {
         this.subscriptionId = subscriptionId;
         this.trackingId = trackingId;
-        this.unitUsageRecord = unitUsageRecord;
+        this.unitUsageRecord = List.copyOf(unitUsageRecord);
     }
 
     public UUID getSubscriptionId() {
@@ -44,6 +44,6 @@ public class SubscriptionUsageRecord {
     }
 
     public List<UnitUsageRecord> getUnitUsageRecord() {
-        return unitUsageRecord;
+        return List.copyOf(unitUsageRecord);
     }
 }

--- a/src/main/java/org/killbill/billing/usage/api/UnitUsageRecord.java
+++ b/src/main/java/org/killbill/billing/usage/api/UnitUsageRecord.java
@@ -28,7 +28,7 @@ public class UnitUsageRecord {
 
     public UnitUsageRecord(final String unitType, final List<UsageRecord> usageRecord) {
         this.unitType = unitType;
-        this.usageRecord = usageRecord;
+        this.usageRecord = List.copyOf(usageRecord);
     }
 
     public String getUnitType() {
@@ -36,6 +36,6 @@ public class UnitUsageRecord {
     }
 
     public List<UsageRecord> getDailyAmount() {
-        return usageRecord;
+        return List.copyOf(usageRecord);
     }
 }

--- a/src/main/java/org/killbill/billing/usage/api/UsageRecord.java
+++ b/src/main/java/org/killbill/billing/usage/api/UsageRecord.java
@@ -21,7 +21,6 @@ package org.killbill.billing.usage.api;
 import java.math.BigDecimal;
 
 import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 
 public class UsageRecord {
 

--- a/src/main/java/org/killbill/billing/util/nodes/DefaultNodeCommandMetadata.java
+++ b/src/main/java/org/killbill/billing/util/nodes/DefaultNodeCommandMetadata.java
@@ -33,12 +33,12 @@ public class DefaultNodeCommandMetadata implements NodeCommandMetadata {
 
     @JsonCreator
     public DefaultNodeCommandMetadata(@JsonProperty("properties") final List<NodeCommandProperty> properties) {
-        this.properties = properties;
+        this.properties = List.copyOf(properties);
     }
 
     @Override
     public List<NodeCommandProperty> getProperties() {
-        return properties;
+        return List.copyOf(properties);
     }
 
     @Override

--- a/src/main/java/org/killbill/billing/util/queue/QueueRetryException.java
+++ b/src/main/java/org/killbill/billing/util/queue/QueueRetryException.java
@@ -17,18 +17,17 @@
 
 package org.killbill.billing.util.queue;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.joda.time.Period;
 
 public class QueueRetryException extends RuntimeException {
 
-    public static final List<Period> DEFAULT_RETRY_SCHEDULE = Arrays.asList(Period.minutes(5),
-                                                                            Period.minutes(15),
-                                                                            Period.hours(1),
-                                                                            Period.hours(6),
-                                                                            Period.hours(24));
+    public static final List<Period> DEFAULT_RETRY_SCHEDULE = List.of(Period.minutes(5),
+                                                                      Period.minutes(15),
+                                                                      Period.hours(1),
+                                                                      Period.hours(6),
+                                                                      Period.hours(24));
 
     private final List<Period> retrySchedule;
 
@@ -50,7 +49,7 @@ public class QueueRetryException extends RuntimeException {
     }
 
     public List<Period> getRetrySchedule() {
-        return retrySchedule;
+        return List.copyOf(retrySchedule);
     }
 
     @Override

--- a/src/main/java/org/killbill/billing/util/tag/ControlTagType.java
+++ b/src/main/java/org/killbill/billing/util/tag/ControlTagType.java
@@ -67,7 +67,7 @@ public enum ControlTagType {
     }
 
     public List<ObjectType> getApplicableObjectTypes() {
-        return applicableObjectTypes;
+        return List.copyOf(applicableObjectTypes);
     }
 
     public static ControlTagType getTypeFromId(final UUID targetId) {


### PR DESCRIPTION
1. Decide to use defensive copy for [Throwable](https://github.com/killbill/killbill-api/compare/work-for-release-0.23.x...xsalefter:api-85-address_spotbugs_errors?expand=1#diff-7fdb21985372d63f2b7452d16cd4f71be71a78a6bbe917fe7acb64c195679154R52).

2. Use `<XXX>.copyOf()` for [List](https://github.com/killbill/killbill-api/compare/work-for-release-0.23.x...xsalefter:api-85-address_spotbugs_errors?expand=1#diff-b081baddfa870fd17f0c349a45a6c5d4e6e5c1d37f79980830a98fd3a003bc7dR35) and [Map](https://github.com/killbill/killbill-api/compare/work-for-release-0.23.x...xsalefter:api-85-address_spotbugs_errors?expand=1#diff-d7b5b65580f09bb6abe9422d241bd6a2393b3437fb2aae00ba7751815ebc7afcR56). This probably cause an issue if other repositories modify those attribute, and need to test. Unfortunately `DefaultBlockingState` in `killbill` repository still not up-to-date with the latest API interfaces from `killbill-api` and have unimplemented interfaces, thus put this as draft.

3. Add Joda's `Period` and `DateTime` in `spotbugs-exclude.xml`. Most of Joda classeses are immutable.