### PR TITLE
invoice: Add InvoicePayment#InvoicePaymentStatus

### DIFF
--- a/src/main/java/org/killbill/billing/invoice/api/InvoicePayment.java
+++ b/src/main/java/org/killbill/billing/invoice/api/InvoicePayment.java
@@ -73,6 +73,6 @@ public interface InvoicePayment extends Entity {
 
     Currency getProcessedCurrency();
 
-    Boolean isSuccess();
+    InvoicePaymentStatus getStatus();
 
 }

--- a/src/main/java/org/killbill/billing/invoice/api/InvoicePaymentStatus.java
+++ b/src/main/java/org/killbill/billing/invoice/api/InvoicePaymentStatus.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api;
+
+public enum InvoicePaymentStatus {
+    INIT,
+    PENDING,
+    SUCCESS,
+}


### PR DESCRIPTION
In order to keep things simple, I only introduced 3 states (not introducing a `FAILED` state, so `INIT` still means that we had an invoice payment recorded or that it never transitioned to `SUCCESS` or `PENDING`, and yet could be failed on the payment side. This choice is certainly up for debate, happy to add it if my reviewers think this is best.
