### PR TITLE
entitlement: add BCD_UPDATE and QUANTITY_UPDATE subscription event types

### DIFF
--- a/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventType.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventType.java
@@ -35,6 +35,10 @@ public enum SubscriptionEventType {
     PHASE(ObjectType.SUBSCRIPTION_EVENT),
     /* User generated change plan */
     CHANGE(ObjectType.SUBSCRIPTION_EVENT),
+    /* Billing cycle day update for a specific subscription */
+    BCD_UPDATE(ObjectType.SUBSCRIPTION_EVENT),
+    /* Quantity update for a specific subscription */
+    QUANTITY_UPDATE(ObjectType.SUBSCRIPTION_EVENT),
     /* User generated cancel */
     STOP_ENTITLEMENT(ObjectType.BLOCKING_STATES),
     STOP_BILLING(ObjectType.SUBSCRIPTION_EVENT),


### PR DESCRIPTION
SubscriptionBaseTransitionType has had BCD_CHANGE and QUANTITY_CHANGE entries for some time, but the corresponding SubscriptionEventType values were never added. This means callers of Subscription.getEvents() never see BCD or quantity transitions in the returned event list.

Add BCD_UPDATE and QUANTITY_UPDATE as SUBSCRIPTION_EVENT entries so that subscription event streams expose these transitions alongside PHASE, CHANGE, and other existing types.